### PR TITLE
Enhance Andor's read-replica hbase-docker repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk \
     DATA_DIR=/data-store
 
 # Install necessary runtime packages
-RUN INITRD=no DEBIAN_FRONTEND=noninteractive microdnf update -y && microdnf install -y unzip gzip wget hostname maven git diffutils vim openssh-clients python3
+RUN INITRD=no DEBIAN_FRONTEND=noninteractive microdnf update -y && microdnf install -y unzip gzip wget hostname maven git diffutils vim openssh-clients python3 procps
 
 # Copy the built HBase binaries from the build-stage
 COPY --from=build-stage /opt/hbase-src/hbase-assembly/target/hbase-4.0.0-alpha-1-SNAPSHOT-bin.tar.gz /opt/
@@ -87,6 +87,10 @@ USER ${HBASE_USER}
 
 # Create necessary directories for HBase to run
 RUN mkdir -p "$DATA_DIR"/hbase "$DATA_DIR"/run "$DATA_DIR"/logs
+
+# Add the 'ls -l' alias
+RUN echo 'alias ll="ls -l"' >> /home/hbase/.bashrc
+RUN echo 'alias ll="ls -l"' >> /home/jboss/.bashrc
 
 # Start HBase and keep it running
 ENTRYPOINT ["/bin/bash", "-c", "${HBASE_HOME}/bin/start-hbase.sh && tail -f ${HBASE_LOGS_DIR}/*.log"]

--- a/README.md
+++ b/README.md
@@ -22,12 +22,23 @@ global read-only mode enabled.
 2. Create `.env` with the correct details.
    ```bash
    HBASE_IMAGE=vhegde/hbase-docker
+   HBASE_CONF_DIR=/opt/hbase/conf
    ```
-3. Make the build script executable:
+3. Modify the paths in your `docker-compose.yml` file to be compatible with your filesystem. For example, change:
+   ```
+   volumes:
+     - /Users/andor/tmp/data-store/hbase:/data-store/hbase
+   ```
+   To:
+   ```
+   volumes:
+     - /Users/<YOUR-USERNAME>/tmp/data-store/hbase:/data-store/hbase
+   ```
+4. Make the build script executable:
    ```bash
    chmod +x build-images.sh
    ```
-4. Build the images:
+5. Build the images:
    ```bash
    ./build-images.sh
    ```

--- a/conf1/hbase-site.xml
+++ b/conf1/hbase-site.xml
@@ -51,5 +51,17 @@
     <name>hbase.master.hbck.chore.interval</name>
     <value>0</value>
   </property>
+  <property>
+    <name>hbase.coprocessor.master.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
+  </property>
+  <property>
+    <name>hbase.coprocessor.regionserver.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
+  </property>
+  <property>
+    <name>hbase.coprocessor.region.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
+  </property>
 
 </configuration>

--- a/conf2/hbase-site.xml
+++ b/conf2/hbase-site.xml
@@ -69,8 +69,24 @@
     <value>replica1</value>
   </property>
   <property>
+    <name>hbase.global.readonly.enabled</name>
+    <value>true</value>
+  </property>
+  <property>
     <name>hbase.master.hbck.chore.interval</name>
     <value>0</value>
+  </property>
+  <property>
+    <name>hbase.coprocessor.master.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
+  </property>
+  <property>
+    <name>hbase.coprocessor.regionserver.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
+  </property>
+  <property>
+    <name>hbase.coprocessor.region.classes</name>
+    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
   </property>
 
 </configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.8'
 
+# Variables are created in .env file
 services:
   hbase:
     image: "${HBASE_IMAGE}"


### PR DESCRIPTION
This pull request makes some additions to @anmolnar's hbase-docker repo.  The repo allows for a two-cluster setup that can be used for testing the HBase Read-Replica feature.  The enhancements in this PR allow for an easier setup process and some extra documentation.  The changes include the following:

1. Update the README doc to tell the user to use their own paths in `docker-compose.yml`.
2. Update the README doc to tell the user to add `HBASE_CONF_DIR` to their `.env` file.
3. Install `procps` on the docker container so `ps` can be used.
4. Add `ls -l` alias to `.bashrc` for the `jboss` and `hbase` users.
5. Add `ReadOnlyController` to the `hbase-site.xml` files.
6. Add `hbase.global.readonly.enabled` and set it to `true` for `conf2/hbase-site.xml`.