### PR TITLE
Remove duplicate hbase.global.readonly.enabled and ReadOnlyController properties

### DIFF
--- a/conf1/hbase-site.xml
+++ b/conf1/hbase-site.xml
@@ -51,17 +51,4 @@
     <name>hbase.master.hbck.chore.interval</name>
     <value>0</value>
   </property>
-  <property>
-    <name>hbase.coprocessor.master.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.regionserver.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.region.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-
 </configuration>

--- a/conf1/log4j2.properties
+++ b/conf1/log4j2.properties
@@ -1,0 +1,137 @@
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+status = warn
+dest = err
+name = PropertiesConfig
+
+# Console appender
+appender.console.type = Console
+appender.console.target = SYSTEM_ERR
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %c{2}: %.1000m%n
+
+# Daily Rolling File Appender
+appender.DRFA.type = RollingFile
+appender.DRFA.name = DRFA
+appender.DRFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.DRFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%d{yyyy-MM-dd}
+appender.DRFA.createOnDemand = true
+appender.DRFA.layout.type = PatternLayout
+appender.DRFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.DRFA.policies.type = Policies
+appender.DRFA.policies.time.type = TimeBasedTriggeringPolicy
+appender.DRFA.policies.time.interval = 1
+appender.DRFA.policies.time.modulate = true
+appender.DRFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.DRFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.DRFA.strategy.type = DefaultRolloverStrategy
+appender.DRFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Rolling File Appender
+appender.RFA.type = RollingFile
+appender.RFA.name = RFA
+appender.RFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.RFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%i
+appender.RFA.createOnDemand = true
+appender.RFA.layout.type = PatternLayout
+appender.RFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFA.policies.type = Policies
+appender.RFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.RFA.strategy.type = DefaultRolloverStrategy
+appender.RFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Security Audit Appender
+appender.RFAS.type = RollingFile
+appender.RFAS.name = RFAS
+appender.RFAS.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}
+appender.RFAS.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}.%i
+appender.RFAS.createOnDemand = true
+appender.RFAS.layout.type = PatternLayout
+appender.RFAS.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFAS.policies.type = Policies
+appender.RFAS.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFAS.policies.size.size = ${sys:hbase.security.log.maxfilesize:-256MB}
+appender.RFAS.strategy.type = DefaultRolloverStrategy
+appender.RFAS.strategy.max = ${sys:hbase.security.log.maxbackupindex:-20}
+
+# Http Access Log RFA, uncomment this if you want an http access.log
+# appender.AccessRFA.type = RollingFile
+# appender.AccessRFA.name = AccessRFA
+# appender.AccessRFA.fileName = /var/log/hbase/access.log
+# appender.AccessRFA.filePattern = /var/log/hbase/access.log.%i
+# appender.AccessRFA.createOnDemand = true
+# appender.AccessRFA.layout.type = PatternLayout
+# appender.AccessRFA.layout.pattern = %m%n
+# appender.AccessRFA.policies.type = Policies
+# appender.AccessRFA.policies.size.type = SizeBasedTriggeringPolicy
+# appender.AccessRFA.policies.size.size = 200MB
+# appender.AccessRFA.strategy.type = DefaultRolloverStrategy
+# appender.AccessRFA.strategy.max = 10
+
+# Null Appender
+appender.NullAppender.type = Null
+appender.NullAppender.name = NullAppender
+
+rootLogger = ${sys:hbase.root.logger:-INFO,console}
+
+logger.SecurityLogger.name = SecurityLogger
+logger.SecurityLogger = ${sys:hbase.security.logger:-INFO,console}
+logger.SecurityLogger.additivity = false
+
+# Custom Logging levels
+# logger.zookeeper.name = org.apache.zookeeper
+# logger.zookeeper.level = ERROR
+
+# logger.FSNamesystem.name = org.apache.hadoop.fs.FSNamesystem
+# logger.FSNamesystem.level = DEBUG
+
+logger.hbase.name = org.apache.hadoop.hbase
+logger.hbase.level = DEBUG
+
+# logger.META.name = org.apache.hadoop.hbase.META
+# logger.META.level = DEBUG
+
+# Make these two classes below DEBUG to see more zk debug.
+# logger.ZKUtil.name = org.apache.hadoop.hbase.zookeeper.ZKUtil
+# logger.ZKUtil.level = DEBUG
+
+# logger.ZKWatcher.name = org.apache.hadoop.hbase.zookeeper.ZKWatcher
+# logger.ZKWatcher.level = DEBUG
+
+# logger.dfs.name = org.apache.hadoop.dfs
+# logger.dfs.level = DEBUG
+
+# Prevent metrics subsystem start/stop messages (HBASE-17722)
+logger.MetricsConfig.name = org.apache.hadoop.metrics2.impl.MetricsConfig
+logger.MetricsConfig.level = WARN
+
+logger.MetricsSinkAdapte.name = org.apache.hadoop.metrics2.impl.MetricsSinkAdapter
+logger.MetricsSinkAdapte.level = WARN
+
+logger.MetricsSystemImpl.name = org.apache.hadoop.metrics2.impl.MetricsSystemImpl
+logger.MetricsSystemImpl.level = WARN
+
+# Disable request log by default, you can enable this by changing the appender
+logger.http.name = http.requests
+logger.http.additivity = false
+logger.http = INFO,NullAppender
+# Replace the above with this configuration if you want an http access.log
+# logger.http = INFO,AccessRFA

--- a/conf2/hbase-site.xml
+++ b/conf2/hbase-site.xml
@@ -48,19 +48,6 @@
   </property>
 
   <property>
-    <name>hbase.coprocessor.master.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.regionserver.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.region.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-
-  <property>
     <name>hbase.meta.table.suffix</name>
     <value>replica1</value>
   </property>

--- a/conf2/hbase-site.xml
+++ b/conf2/hbase-site.xml
@@ -48,10 +48,6 @@
   </property>
 
   <property>
-    <name>hbase.global.readonly.enabled</name>
-    <value>true</value>
-  </property>
-  <property>
     <name>hbase.coprocessor.master.classes</name>
     <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
   </property>

--- a/conf2/hbase-site.xml
+++ b/conf2/hbase-site.xml
@@ -18,10 +18,6 @@
     <value>file:///data-store/wal</value>
   </property>
   <property>
-    <name>hbase.master.store.dir</name>
-    <value>MasterData2</value>
-  </property>
-  <property>
     <name>hbase.store.file-tracker.impl</name>
     <value>FILE</value>
   </property>
@@ -59,17 +55,4 @@
     <name>hbase.master.hbck.chore.interval</name>
     <value>0</value>
   </property>
-  <property>
-    <name>hbase.coprocessor.master.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.regionserver.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-  <property>
-    <name>hbase.coprocessor.region.classes</name>
-    <value>org.apache.hadoop.hbase.security.access.ReadOnlyController</value>
-  </property>
-
 </configuration>

--- a/conf2/log4j2.properties
+++ b/conf2/log4j2.properties
@@ -1,0 +1,137 @@
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+status = warn
+dest = err
+name = PropertiesConfig
+
+# Console appender
+appender.console.type = Console
+appender.console.target = SYSTEM_ERR
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %c{2}: %.1000m%n
+
+# Daily Rolling File Appender
+appender.DRFA.type = RollingFile
+appender.DRFA.name = DRFA
+appender.DRFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.DRFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%d{yyyy-MM-dd}
+appender.DRFA.createOnDemand = true
+appender.DRFA.layout.type = PatternLayout
+appender.DRFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.DRFA.policies.type = Policies
+appender.DRFA.policies.time.type = TimeBasedTriggeringPolicy
+appender.DRFA.policies.time.interval = 1
+appender.DRFA.policies.time.modulate = true
+appender.DRFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.DRFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.DRFA.strategy.type = DefaultRolloverStrategy
+appender.DRFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Rolling File Appender
+appender.RFA.type = RollingFile
+appender.RFA.name = RFA
+appender.RFA.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}
+appender.RFA.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.log.file:-hbase.log}.%i
+appender.RFA.createOnDemand = true
+appender.RFA.layout.type = PatternLayout
+appender.RFA.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFA.policies.type = Policies
+appender.RFA.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFA.policies.size.size = ${sys:hbase.log.maxfilesize:-256MB}
+appender.RFA.strategy.type = DefaultRolloverStrategy
+appender.RFA.strategy.max = ${sys:hbase.log.maxbackupindex:-20}
+
+# Security Audit Appender
+appender.RFAS.type = RollingFile
+appender.RFAS.name = RFAS
+appender.RFAS.fileName = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}
+appender.RFAS.filePattern = ${sys:hbase.log.dir:-.}/${sys:hbase.security.log.file:-SecurityAuth.audit}.%i
+appender.RFAS.createOnDemand = true
+appender.RFAS.layout.type = PatternLayout
+appender.RFAS.layout.pattern = %d{ISO8601} %-5p [%t] %c{2}: %.1000m%n
+appender.RFAS.policies.type = Policies
+appender.RFAS.policies.size.type = SizeBasedTriggeringPolicy
+appender.RFAS.policies.size.size = ${sys:hbase.security.log.maxfilesize:-256MB}
+appender.RFAS.strategy.type = DefaultRolloverStrategy
+appender.RFAS.strategy.max = ${sys:hbase.security.log.maxbackupindex:-20}
+
+# Http Access Log RFA, uncomment this if you want an http access.log
+# appender.AccessRFA.type = RollingFile
+# appender.AccessRFA.name = AccessRFA
+# appender.AccessRFA.fileName = /var/log/hbase/access.log
+# appender.AccessRFA.filePattern = /var/log/hbase/access.log.%i
+# appender.AccessRFA.createOnDemand = true
+# appender.AccessRFA.layout.type = PatternLayout
+# appender.AccessRFA.layout.pattern = %m%n
+# appender.AccessRFA.policies.type = Policies
+# appender.AccessRFA.policies.size.type = SizeBasedTriggeringPolicy
+# appender.AccessRFA.policies.size.size = 200MB
+# appender.AccessRFA.strategy.type = DefaultRolloverStrategy
+# appender.AccessRFA.strategy.max = 10
+
+# Null Appender
+appender.NullAppender.type = Null
+appender.NullAppender.name = NullAppender
+
+rootLogger = ${sys:hbase.root.logger:-INFO,console}
+
+logger.SecurityLogger.name = SecurityLogger
+logger.SecurityLogger = ${sys:hbase.security.logger:-INFO,console}
+logger.SecurityLogger.additivity = false
+
+# Custom Logging levels
+# logger.zookeeper.name = org.apache.zookeeper
+# logger.zookeeper.level = ERROR
+
+# logger.FSNamesystem.name = org.apache.hadoop.fs.FSNamesystem
+# logger.FSNamesystem.level = DEBUG
+
+logger.hbase.name = org.apache.hadoop.hbase
+logger.hbase.level = DEBUG
+
+# logger.META.name = org.apache.hadoop.hbase.META
+# logger.META.level = DEBUG
+
+# Make these two classes below DEBUG to see more zk debug.
+# logger.ZKUtil.name = org.apache.hadoop.hbase.zookeeper.ZKUtil
+# logger.ZKUtil.level = DEBUG
+
+# logger.ZKWatcher.name = org.apache.hadoop.hbase.zookeeper.ZKWatcher
+# logger.ZKWatcher.level = DEBUG
+
+# logger.dfs.name = org.apache.hadoop.dfs
+# logger.dfs.level = DEBUG
+
+# Prevent metrics subsystem start/stop messages (HBASE-17722)
+logger.MetricsConfig.name = org.apache.hadoop.metrics2.impl.MetricsConfig
+logger.MetricsConfig.level = WARN
+
+logger.MetricsSinkAdapte.name = org.apache.hadoop.metrics2.impl.MetricsSinkAdapter
+logger.MetricsSinkAdapte.level = WARN
+
+logger.MetricsSystemImpl.name = org.apache.hadoop.metrics2.impl.MetricsSystemImpl
+logger.MetricsSystemImpl.level = WARN
+
+# Disable request log by default, you can enable this by changing the appender
+logger.http.name = http.requests
+logger.http.additivity = false
+logger.http = INFO,NullAppender
+# Replace the above with this configuration if you want an http access.log
+# logger.http = INFO,AccessRFA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     hostname: hbase-docker
     volumes:
       - ./utils:/opt/utils
-      - /Users/andor/tmp/data-store/hbase:/data-store/hbase
+      - /Users/kgeiszler/tmp/data-store/hbase:/data-store/hbase
       - ./conf1/hbase-site.xml:${HBASE_CONF_DIR}/hbase-site.xml
       - ./conf1/zoo.cfg:${HBASE_CONF_DIR}/zoo.cfg
 
@@ -18,7 +18,7 @@ services:
     hostname: hbase-docker-2
     volumes:
       - ./utils:/opt/utils
-      - /Users/andor/tmp/data-store/hbase:/data-store/hbase
+      - /Users/kgeiszler/tmp/data-store/hbase:/data-store/hbase
       - ./conf2/hbase-site.xml:${HBASE_CONF_DIR}/hbase-site.xml
       - ./conf2/zoo.cfg:${HBASE_CONF_DIR}/zoo.cfg
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - /Users/kgeiszler/tmp/data-store/hbase:/data-store/hbase
       - ./conf1/hbase-site.xml:${HBASE_CONF_DIR}/hbase-site.xml
       - ./conf1/zoo.cfg:${HBASE_CONF_DIR}/zoo.cfg
+      - ./conf1/log4j2.properties:${HBASE_CONF_DIR}/log4j2.properties
 
   hbase2:
     image: "${HBASE_IMAGE}"
@@ -21,4 +22,4 @@ services:
       - /Users/kgeiszler/tmp/data-store/hbase:/data-store/hbase
       - ./conf2/hbase-site.xml:${HBASE_CONF_DIR}/hbase-site.xml
       - ./conf2/zoo.cfg:${HBASE_CONF_DIR}/zoo.cfg
-
+      - ./conf2/log4j2.properties:${HBASE_CONF_DIR}/log4j2.properties


### PR DESCRIPTION
`conf2/hbase-site.xml` has two separate `hbase.global.readonly.enabled` and `ReadOnlyController` properties.  This pull request removes one version of each of them.